### PR TITLE
[Fix] Simplify error descriptions in API documentation

### DIFF
--- a/src/route/game.route.ts
+++ b/src/route/game.route.ts
@@ -56,7 +56,7 @@ router.post("/upload/:gameId", async (req, res) => {
  *                 url:
  *                   type: string
  *       400:
- *         description: 잘못된 요청 (예: 잘못된 gameId)
+ *         description: 잘못된 요청
  *       500:
  *         description: 서버 오류
  */

--- a/src/route/resource.route.ts
+++ b/src/route/resource.route.ts
@@ -48,7 +48,7 @@ router.post("/upload/:resourceId", async (req, res) => {
  *                 url:
  *                   type: string
  *       400:
- *         description: 잘못된 요청 (예: 잘못된 resourceId)
+ *         description: 잘못된 요청
  *       500:
  *         description: 서버 오류
  */


### PR DESCRIPTION
Removed specific examples from 400 error descriptions in `game.route.ts` and `resource.route.ts` to make the documentation more concise and generic. This improves readability and ensures consistency across the API documentation.