### PR TITLE
feat: Update Swagger server URL in configuration

### DIFF
--- a/src/config/swagger.config.ts
+++ b/src/config/swagger.config.ts
@@ -19,7 +19,7 @@ const options = {
     },
     servers: [
       {
-        url: 'http://3.37.46.45:30355',
+        url: 'http://16.184.9.194:30355',
         description: 'Upload 서비스 API 서버'
       }
     ],


### PR DESCRIPTION
Replaced the old server URL with the new IP address to reflect the updated API server location. Ensures proper connectivity and accurate documentation for the Upload service.