### PR TITLE
feat: Update API routes and Swagger server URL for Upload service

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -14,11 +14,11 @@ app.use(cors({
 }))
 
 // Swagger UI 설정
-app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(specs, swaggerUiOptions));
+app.use('/upload/api-docs', swaggerUi.serve, swaggerUi.setup(specs, swaggerUiOptions));
 
 // jwt middleware
-app.use('/api/protected', jwtGuard);
-app.use('/api/protected/game', gameRoute);
-app.use('/api/protected/resource', resourceRoute);
+app.use('/upload/api/protected', jwtGuard);
+app.use('/upload/api/protected/game', gameRoute);
+app.use('/upload/api/protected/resource', resourceRoute);
 
 export default app;

--- a/src/config/swagger.config.ts
+++ b/src/config/swagger.config.ts
@@ -19,7 +19,7 @@ const options = {
     },
     servers: [
       {
-        url: 'http://16.184.9.194:30355',
+        url: 'http://api.uosludex.com/upload',
         description: 'Upload 서비스 API 서버'
       }
     ],


### PR DESCRIPTION
Modified API route prefixes to include `/upload`, adapting to the new route structure for the Upload service. Updated Swagger server URL in configuration for accurate API documentation.