### PR TITLE
feat: Expand CORS origins to include localhost and production domains

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -9,7 +9,7 @@ import resourceRoute from "./route/resource.route";
 const app : Express = express();
 app.use(express.json());
 app.use(cors({
-    origin: process.env.CLIENT_ORIGIN,
+    origin: ['http://localhost:3000', 'http://uosludex.com', 'https://uosludex.com'],
     credentials: true
 }))
 


### PR DESCRIPTION
Updated the CORS configuration to allow requests from `http://localhost:3000` and both `http://uosludex.com` and `https://uosludex.com` for better compatibility across development and production environments.