### PR TITLE
feat: Update Swagger server URL to use HTTPS for Upload service

### DIFF
--- a/src/config/swagger.config.ts
+++ b/src/config/swagger.config.ts
@@ -19,7 +19,7 @@ const options = {
     },
     servers: [
       {
-        url: 'http://api.uosludex.com/upload',
+        url: 'https://api.uosludex.com/upload',
         description: 'Upload 서비스 API 서버'
       }
     ],


### PR DESCRIPTION
Replaced `http` with `https` in the Swagger server URL to ensure secure API communication for the Upload service.